### PR TITLE
Chore: API 명세 확인을 위한 Swagger 환경 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	// 소셜로그인
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	// PostgreSQL 연동
 	runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/sosaw/sosaw/global/config/SecurityConfig.java
+++ b/src/main/java/com/sosaw/sosaw/global/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/profile").hasRole("ADMIN") // ADMIN 역할 가진 사용자만 접근 가능
                         .requestMatchers("kakao-login-test.html").permitAll()
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                        .requestMatchers("/static/js/**","/static/css/**","/static/img/**"
+                                ,"/swagger-ui/**","/v3/api-docs/**").permitAll() // swagger
                         .anyRequest().authenticated() // 로그인한 사용자만 접근 허용
                 )
 

--- a/src/main/java/com/sosaw/sosaw/global/config/SwaggerConfig.java
+++ b/src/main/java/com/sosaw/sosaw/global/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.sosaw.sosaw.global.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("sosaw")
+                .version("v0.0.1")
+                .description("공학경진대회 sosaw의 API 명세서");
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #6 
<br>

## ✅ 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- SecurityConfig에 Swagger 관련 접근 허용 설정 추가
- SwaggerConfig 작성하여 API 문서화 설정
- build.gradle에 springdoc-openapi 의존성 추가

<br>

## 👥 전달사항
<!--
  ex)
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [ ] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨
- [ ] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
http://localhost:8080/swagger-ui/index.html 경로로 들어갔을 때의 모습
<img width="1680" height="663" alt="스크린샷 2025-08-31 오후 9 15 05" src="https://github.com/user-attachments/assets/d039a8eb-ec30-4a8f-9017-eb38671c326a" />
