### PR TITLE
feat: 알람유무 수정, 진동 종류 수정 API에 기본 소리 추가하도록 수정

### DIFF
--- a/src/main/java/com/sosaw/sosaw/domain/basicsound/entity/BasicSound.java
+++ b/src/main/java/com/sosaw/sosaw/domain/basicsound/entity/BasicSound.java
@@ -1,0 +1,26 @@
+package com.sosaw.sosaw.domain.basicsound.entity;
+
+import com.sosaw.sosaw.domain.basicsound.entity.enums.BasicSoundType;
+import com.sosaw.sosaw.domain.soundsetting.entity.SoundSetting;
+import com.sosaw.sosaw.domain.user.entity.User;
+import com.sosaw.sosaw.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "Basic_Sound")
+public class BasicSound extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="basic_id")
+    private Long id; // pk
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sound_type", nullable = false, length = 30)
+    private BasicSoundType soundType; // 기본음 소리 종류를 구분하기 위함
+}

--- a/src/main/java/com/sosaw/sosaw/domain/basicsound/entity/enums/BasicSoundType.java
+++ b/src/main/java/com/sosaw/sosaw/domain/basicsound/entity/enums/BasicSoundType.java
@@ -1,0 +1,16 @@
+package com.sosaw.sosaw.domain.basicsound.entity.enums;
+
+public enum BasicSoundType {
+    DOG_BARK,        // 강아지 짓는 소리
+    CAT_MEOW,        // 고양이 소리
+    HUMAN_LAUGH,     // 사람 웃는 소리
+    BABY_CRY,        // 아기 우는 소리
+    PHONE_RING,      // 전화벨 소리
+    DOORBELL,        // 초인종 소리
+    DOOR_OPEN_CLOSE, // 문 여닫는 소리
+    KNOCK,           // 노크 소리
+    FIRE_ALARM,      // 화재 경보기 소리
+    MICROWAVE,       // 전자레인지 소리
+    CAR_HORN,        // 경적 소리
+    SIREN            // 비상 경보음 소리
+}

--- a/src/main/java/com/sosaw/sosaw/domain/basicsound/repository/BasicSoundRepository.java
+++ b/src/main/java/com/sosaw/sosaw/domain/basicsound/repository/BasicSoundRepository.java
@@ -1,0 +1,10 @@
+package com.sosaw.sosaw.domain.basicsound.repository;
+
+import com.sosaw.sosaw.domain.basicsound.entity.BasicSound;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BasicSoundRepository extends JpaRepository<BasicSound, Long> {
+
+}

--- a/src/main/java/com/sosaw/sosaw/domain/customsound/service/CustomSoundServiceImpl.java
+++ b/src/main/java/com/sosaw/sosaw/domain/customsound/service/CustomSoundServiceImpl.java
@@ -44,7 +44,7 @@ public class CustomSoundServiceImpl implements CustomSoundService{
         CustomSound sound = CustomSound.toEntity(user, req, mfcc);
 
         // 커스텀 소리를 생성할때, SoundSetting 부분도 같이 생기게 함
-        SoundSetting.createForCustom(sound);
+        SoundSetting.createForCustom(user,sound);
 
         customSoundRepository.save(sound);
     }

--- a/src/main/java/com/sosaw/sosaw/domain/soundsetting/repository/SoundSettingRepository.java
+++ b/src/main/java/com/sosaw/sosaw/domain/soundsetting/repository/SoundSettingRepository.java
@@ -11,4 +11,8 @@ public interface SoundSettingRepository extends JpaRepository<SoundSetting, Long
 
     // CustomSound id로 SoundSetting 조회
     Optional<SoundSetting> findByCustomSoundId(Long customId);
+
+    Optional<SoundSetting> findByUserUserIdAndCustomSoundId(Long userId, Long customId);
+    Optional<SoundSetting> findByUserUserIdAndBasicSoundId(Long userId, Long basicId);
+
 }

--- a/src/main/java/com/sosaw/sosaw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sosaw/sosaw/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,9 @@
 package com.sosaw.sosaw.domain.user.service;
 
+import com.sosaw.sosaw.domain.basicsound.entity.BasicSound;
+import com.sosaw.sosaw.domain.basicsound.repository.BasicSoundRepository;
+import com.sosaw.sosaw.domain.soundsetting.entity.SoundSetting;
+import com.sosaw.sosaw.domain.soundsetting.repository.SoundSettingRepository;
 import com.sosaw.sosaw.domain.user.entity.User;
 import com.sosaw.sosaw.domain.user.exception.PasswordMismatchException;
 import com.sosaw.sosaw.domain.user.exception.UserAlreadyExistException;
@@ -14,11 +18,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final BasicSoundRepository basicSoundRepository;
+    private final SoundSettingRepository soundSettingRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -39,6 +47,13 @@ public class UserServiceImpl implements UserService {
 
         // Repository에 User 저장
         userRepository.save(user);
+
+        // 기본 사운드 세팅 생성
+        List<BasicSound> basics = basicSoundRepository.findAll();
+        for (BasicSound basic : basics) {
+            SoundSetting setting = SoundSetting.createForBasic(user, basic);
+            soundSettingRepository.save(setting);
+        }
     }
 
     // 회원가입시, 아이디 중복 확인


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #36 
<br>

## ✅ 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [x] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- 기본음 엔티티 추가 (pk와 소리 종류를 구별할 수 있는 이넘타입 필드만 존재)
- 회원가입시, soundSetting 테이블에 자동으로 기본음이 추가되도록 기능 추가

<br>

## 👥 전달사항
<!--
  ex)
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [ ] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨
- [ ] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->

