### PR TITLE
✨ feat : 알림, 진동 상태 조회 api 구현

### DIFF
--- a/src/main/java/com/sosaw/sosaw/domain/soundsetting/repository/SoundSettingRepository.java
+++ b/src/main/java/com/sosaw/sosaw/domain/soundsetting/repository/SoundSettingRepository.java
@@ -4,6 +4,7 @@ import com.sosaw.sosaw.domain.soundsetting.entity.SoundSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,5 @@ public interface SoundSettingRepository extends JpaRepository<SoundSetting, Long
     Optional<SoundSetting> findByUserUserIdAndCustomSoundId(Long userId, Long customId);
     Optional<SoundSetting> findByUserUserIdAndBasicSoundId(Long userId, Long basicId);
 
+    List<SoundSetting> findByUserUserId(Long userId);
 }

--- a/src/main/java/com/sosaw/sosaw/domain/soundsetting/service/SoundSettingService.java
+++ b/src/main/java/com/sosaw/sosaw/domain/soundsetting/service/SoundSettingService.java
@@ -1,10 +1,17 @@
 package com.sosaw.sosaw.domain.soundsetting.service;
 
 import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundAlarmUpdateReq;
+import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundSettingRes;
 import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundVibrationUpdateReq;
 import com.sosaw.sosaw.domain.user.entity.User;
+import com.sosaw.sosaw.global.security.CustomUserDetails;
+
+import java.util.List;
 
 public interface SoundSettingService {
+
+    // 알림 설정 조회
+    List<SoundSettingRes> getAllSoundSetting(User user);
 
     // 알람 유무 수정
     void updateAlarm(User user, SoundAlarmUpdateReq req);

--- a/src/main/java/com/sosaw/sosaw/domain/soundsetting/service/SoundSettingServiceImpl.java
+++ b/src/main/java/com/sosaw/sosaw/domain/soundsetting/service/SoundSettingServiceImpl.java
@@ -8,11 +8,14 @@ import com.sosaw.sosaw.domain.customsound.repository.CustomSoundRepository;
 import com.sosaw.sosaw.domain.soundsetting.entity.SoundSetting;
 import com.sosaw.sosaw.domain.soundsetting.repository.SoundSettingRepository;
 import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundAlarmUpdateReq;
+import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundSettingRes;
 import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundVibrationUpdateReq;
 import com.sosaw.sosaw.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +24,36 @@ public class SoundSettingServiceImpl implements SoundSettingService {
     private final BasicSoundRepository basicSoundRepository;
     private final CustomSoundRepository customSoundRepository;
     private final SoundSettingRepository soundSettingRepository;
+
+    @Override
+    @Transactional
+    public List<SoundSettingRes> getAllSoundSetting(User user) {
+        //모든 사운드 설정 조회
+        List<SoundSetting> settings = soundSettingRepository.findByUserUserId(user.getUserId());
+
+        //기본 사운드 설정 조회
+        List<BasicSound> basicSounds = basicSoundRepository.findAll();
+
+        //기본 사운드 존재 확인
+        for(BasicSound basicSound : basicSounds) {
+            boolean exists = false;
+            for(SoundSetting setting : settings) {
+                if(setting.getBasicSound() != null &&
+                setting.getBasicSound().getId().equals(basicSound.getId())) {
+                    exists = true;
+                    break;
+                }
+            }
+            if(!exists) {
+                SoundSetting newSetting = SoundSetting.createForBasic(user, basicSound);
+                soundSettingRepository.save(newSetting);
+                settings.add(newSetting);
+            }
+        }
+
+
+        return settings.stream().map(SoundSettingRes::from).toList();
+    }
 
     @Override
     @Transactional

--- a/src/main/java/com/sosaw/sosaw/domain/soundsetting/web/controller/SoundSettingController.java
+++ b/src/main/java/com/sosaw/sosaw/domain/soundsetting/web/controller/SoundSettingController.java
@@ -1,19 +1,21 @@
 package com.sosaw.sosaw.domain.soundsetting.web.controller;
 
+import com.sosaw.sosaw.domain.soundsetting.entity.SoundSetting;
 import com.sosaw.sosaw.domain.soundsetting.service.SoundSettingService;
 import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundAlarmUpdateReq;
+import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundSettingRes;
 import com.sosaw.sosaw.domain.soundsetting.web.dto.SoundVibrationUpdateReq;
 import com.sosaw.sosaw.global.response.SuccessResponse;
 import com.sosaw.sosaw.global.security.CustomUserDetails;
+import com.sun.net.httpserver.Authenticator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class SoundSettingController {
 
     private final SoundSettingService soundSettingService;
+
+    //사운드 종류/알림/진동 조회
+    @GetMapping("")
+    public ResponseEntity<SuccessResponse<?>> getAllSoundSettings(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+       List<SoundSettingRes> res = soundSettingService.getAllSoundSetting(userDetails.getUser());
+        return ResponseEntity.status(
+                HttpStatus.OK).body(SuccessResponse.ok(res));
+    }
 
     // 알람 유무 수정
     @PutMapping("/alarm")

--- a/src/main/java/com/sosaw/sosaw/domain/soundsetting/web/dto/SoundSettingRes.java
+++ b/src/main/java/com/sosaw/sosaw/domain/soundsetting/web/dto/SoundSettingRes.java
@@ -1,0 +1,30 @@
+package com.sosaw.sosaw.domain.soundsetting.web.dto;
+
+import com.sosaw.sosaw.domain.customsound.entity.enums.Color;
+import com.sosaw.sosaw.domain.soundsetting.entity.SoundSetting;
+import com.sosaw.sosaw.domain.soundsetting.entity.enums.SoundKind;
+
+public record SoundSettingRes(
+        String soundName,
+        String emoji,
+        Color color,
+        boolean alarmEnabled,
+        int vibrationLevel
+
+) {
+    public static SoundSettingRes from(SoundSetting setting) {
+        return new SoundSettingRes(
+                setting.getSoundKind() == SoundKind.DEFAULT
+                        ? setting.getBasicSound().getSoundType().toString()
+                        : setting.getCustomSound().getCustomName(),
+                setting.getSoundKind() == SoundKind.DEFAULT
+                        ? null
+                        : setting.getCustomSound().getEmoji(),
+                setting.getSoundKind() == SoundKind.DEFAULT
+                        ? null
+                        : setting.getCustomSound().getColor(),
+                setting.isAlarmEnabled(),
+                setting.getVibrationLevel()
+        );
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close : #40 

<br>

## ✅ 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 기능 수정

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
설정탭에서 알림, 진동 상태를 조회하는 api를 구현했습니다.

<br>

## 👥 전달사항
<!--
  ex)
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->
- basic, custom 둘 다 같은 dto을 두고 basic일때만 이모지와 색상을 null로 반환하도록 하였습니다.
- basic 소리의 soundSetting 객체가 없다면 처음 조회할때 생성하도록 구현하였습니다. (12종의 basicSound의 soundSetting객체 생성)
- 현재 커스텀 소리 추가가 안되는 상황이라 서버 복구하면 커스텀까지 잘 반환되는지 테스트 해보겠습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [ ] 모든 테스트가 통과함
- [ ] 관련 문서가 업데이트됨
- [ ] 코드 리뷰가 수행됨
- [ ] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="1178" height="653" alt="image" src="https://github.com/user-attachments/assets/c7b6ceb4-9129-440b-ac84-ca2d5c172504" />

